### PR TITLE
fix bug in filtering file extensions

### DIFF
--- a/src/flyswot/core.py
+++ b/src/flyswot/core.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from typing import Any
 from typing import Iterable
 from typing import Iterator
+from typing import List
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 from toolz import itertoolz  # type: ignore
 
@@ -32,20 +34,28 @@ def get_image_files_from_pattern(directory: Path, pattern: str) -> Iterator[Path
         console.log("Search files complete...")
 
 
-def filter_to_preferred_ext(files: Iterable[Path], ext: str) -> Iterable[Path]:
+def filter_to_preferred_ext(
+    files: Iterable[Path], ext: Union[str, List[str]]
+) -> Iterable[Path]:
     """filter_to_preferred_ext"""
     files = list(files)
     files_without_ext = (
         file.with_suffix("") for file in files if not file.name.startswith(".")
     )
-    unique = set(itertoolz.unique(files_without_ext))
+    file_names_without_ext = (file.name for file in files_without_ext)
+    unique = set(itertoolz.unique(file_names_without_ext))
+    print(unique)
     for file in files:
-        if file.with_suffix("") in unique:
+        file_without_suffix = file.with_suffix("")
+        print(file_without_suffix.name)
+        if file_without_suffix.name in unique:
+            print(file)
             if file.with_suffix(ext).is_file():
+                print(file)
                 yield file.with_suffix(ext)
             else:
                 yield file
-            unique.discard(file.with_suffix(""))
+            unique.discard(file_without_suffix.name)
 
 
 def signal_last(it: Iterable[Any]) -> Iterable[Tuple[bool, Any]]:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -70,6 +70,25 @@ def test_filter(fname, tmpdir):
     assert len(list(matches)) == 50 + 25
 
 
+@pytest.mark.parametrize("fname", patterns_to_test)
+def test_filter_matching_files(fname, tmpdir):
+    """It filters files from pattern when file in both extensions"""
+    a_dir = tmpdir.mkdir("image_dir")
+    for number in range(50):
+        file = a_dir.join(f"file_{fname}_{number}.tif")
+        file.ensure()
+        file2 = a_dir.join(f"file_{number}.jpg")
+        file2.ensure()
+    files = Path("a_dir").rglob("**/*")
+    matches = core.filter_to_preferred_ext(
+        a_dir,
+        fname,
+    )
+    files = [f for f in Path(a_dir).rglob("**/*") if f.is_file()]
+    assert len(files) == 100
+    assert len(list(matches)) == 50
+
+
 @pytest.fixture()
 def image_files(tmpdir_factory):
     """Fixture for image files"""
@@ -92,6 +111,27 @@ def test_filter_to_preferred_ext(image_files):
     image_files = [f for f in Path(image_files).iterdir()]
     return_files = list(core.filter_to_preferred_ext(image_files, ".jpg"))
     assert len(return_files) == 2000
+
+
+@pytest.mark.parametrize("fname", patterns_to_test)
+def test_filter_matching_files_in_different_directories(fname, tmpdir):
+    """It filters files from pattern when file live in different directories"""
+    img_dir = tmpdir.mkdir("image_dir")
+    tif_dir = img_dir.mkdir("tif")
+    jpg_dir = img_dir.mkdir("jpg")
+    for number in range(50):
+        file = tif_dir.join(f"file_{fname}_{number}.tif")
+        file.ensure()
+        file2 = jpg_dir.join(f"file_{fname}_{number}.jpg")
+        file2.ensure()
+    files = Path(img_dir).rglob("**/*")
+    matches = core.filter_to_preferred_ext(
+        files,
+        ".tif",
+    )
+    files = [f for f in Path(img_dir).rglob("**/*") if f.is_file()]
+    assert len(files) == 100
+    assert len(list(matches)) == 50
 
 
 @given(strategies.lists(int_values, min_size=1))


### PR DESCRIPTION
fixes bug in filtering files to the preferred extension which didn't previously account for files with different parent directories with the same name:

```
item/
	jpg/
		image_1.jpg
	tif/
		image_1.tif