### PR TITLE
Use rglob to search for image files directly

### DIFF
--- a/src/flyswot/core.py
+++ b/src/flyswot/core.py
@@ -19,14 +19,16 @@ image_extensions: Set[str] = {
 }
 
 
-def get_image_files_from_pattern(directory: Path, pattern: str) -> Iterator[Path]:
-    """yield image files from `directory` matching pattern `str`"""
+def get_image_files_from_pattern(
+    directory: Path, pattern: str, ext: str = None
+) -> Iterator[Path]:
+    """yield image files from `directory` matching pattern `str` with `ext`"""
     with console.status(
         f"Searching for files matching {pattern} in {directory}...",
         spinner="dots",
     ):
         time.sleep(1)
-        match_files = Path(directory).rglob(f"**/*{pattern}*")
+        match_files = Path(directory).rglob(f"**/*{pattern}*{ext}")
         for file in match_files:
             if Path(file).suffix in image_extensions:
                 yield file

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -106,9 +106,9 @@ def predict_directory(
     model = model_parts.model
     vocab = models.load_vocab(model_parts.vocab)
     onnxinference = OnnxInferenceSession(model, vocab)
-    files = core.get_image_files_from_pattern(directory, pattern)
-    filtered_files = core.filter_to_preferred_ext(files, [preferred_format])
-    files = list(filtered_files)
+    files = core.get_image_files_from_pattern(directory, pattern, preferred_format)
+    # filtered_files = core.filter_to_preferred_ext(files, [preferred_format])
+    files = list(files)
     typer.echo(f"Found {len(files)} files matching {pattern} in {directory}")
     csv_fname = create_csv_fname(csv_save_dir)
     create_csv_header(csv_fname)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,10 +61,7 @@ def test_filter(fname, tmpdir):
         for i in range(5):
             file = a_sub_dir.join(f"file_{fname}_{i}.tif")
             file.ensure()
-    matches = core.get_image_files_from_pattern(
-        a_dir,
-        fname,
-    )
+    matches = core.get_image_files_from_pattern(a_dir, fname, ".tif")
     files = [f for f in Path(a_dir).rglob("**/*") if f.is_file()]
     assert len(files) == (50 * 2) + 25
     assert len(list(matches)) == 50 + 25
@@ -154,7 +151,6 @@ def test_signal_last(l):
             assert var == last
 
 
-@typing.no_type_check
 def test_signal_last_raises_value_error_with_no_length():
     """It raises value error when no length"""
     with pytest.raises(ValueError):


### PR DESCRIPTION
- use rglob directly for file searching since we don't need to find non-tiff files. 