### PR TITLE
Add support for multi-task flyswot models

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 * text=auto eol=lf
-.onnx filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+.onnx filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2.3.4
+        with:
+          lfs: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2.2.2

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -170,7 +170,14 @@ def predict_directory(
         columns = Columns(tables)
         print(columns)
     else:
-        print_table(list(itertoolz.concat(all_preds)))
+        labels_to_print = labels_from_csv(csv_fname)
+        tables = [
+            print_table(labels, f"Prediction summary {i+1}", print=False)
+            for i, labels in enumerate(labels_to_print)
+        ]
+        columns = Columns(tables)
+        print(columns)
+    # print_table(list(itertoolz.concat(all_preds)))
 
 
 def labels_from_csv(fname: Path) -> List[List[str]]:
@@ -252,7 +259,7 @@ def create_csv_header(batch, csv_path) -> None:
 def _(batch: PredictionBatch, csv_path):
     """Creates a header for csv `csv_path`"""
     with open(csv_path, mode="w", newline="") as csv_file:
-        field_names = ["path", "directory", "predicted_label", "confidence"]
+        field_names = ["path", "directory", "prediction", "confidence"]
         writer = csv.DictWriter(csv_file, fieldnames=field_names)
         writer.writeheader()
 

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -432,5 +432,5 @@ class OnnxInferenceSession(InferenceSession):  # pragma: no cover
             return MultiPredictionBatch(prediction_items)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     app()

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -432,5 +432,5 @@ class OnnxInferenceSession(InferenceSession):  # pragma: no cover
             return MultiPredictionBatch(prediction_items)
 
 
-if __name__ == "__main__":  # pragma: no cover
-    app()
+if __name__ == "__main__":
+    app()  # pragma: no cover

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import Tuple
 from typing import Union
@@ -66,8 +65,22 @@ class PredictionBatch:
     batch: List[ImagePredictionItem]
 
     def __post_init__(self):
-        """Returns a list of all predicted labels in batch"""
-        self.batch_labels: Iterator[str] = (item.predicted_label for item in self.batch)
+        """Returns a iterable of all predicted labels in batch"""
+        self.batch_labels: Iterable[str] = (item.predicted_label for item in self.batch)
+
+
+@dataclass
+class MultiPredictionBatch:
+    """Container for MultiLabelImagePRedictionItems"""
+
+    batch: List[MultiLabelImagePredictionItem]
+
+    def __post_init__(self):
+        """Returns a iterable of lists containing all predicted labels in batch"""
+        self.batch_labels: Iterable = (
+            list(itertoolz.pluck(0, pred))
+            for pred in zip(*[o.predictions for o in self.batch])
+        )
 
 
 image_extensions = {k for k, v in mimetypes.types_map.items() if v.startswith("image/")}

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -125,7 +125,8 @@ def predict_directory(
     image_format: str = typer.Option(
         ".tif", help="Image format for flyswot to use for predictions"
     ),
-    check_latest: bool = typer.Option(True, help="Use latest available model"),
+    # check_latest: bool = typer.Option(True, help="Use latest available model"),
+    model_name: str = typer.Option("latest", help="Which model to use"),
 ):
     """Predicts against all images stored under DIRECTORY which match PATTERN in the filename.
 
@@ -136,8 +137,10 @@ def predict_directory(
     start_time = time.perf_counter()
     model_dir = models.ensure_model_dir()
     # TODO add load learner function that can be passed a model name
-    # model_parts = models.ensure_model(model_dir, check_latest)
-    model_parts = models._get_model_parts(Path(model_dir / "20210629"))
+    if model_name == "latest":
+        model_parts = models.ensure_model(model_dir, check_latest=True)
+    if model_name != "latest":
+        model_parts = models._get_model_parts(Path(model_dir / Path(model_name)))
     onnxinference = OnnxInferenceSession(model_parts.model, model_parts.vocab)
     files = list(core.get_image_files_from_pattern(directory, pattern, image_format))
     check_files(files, pattern, directory)

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -150,10 +150,8 @@ def predict_directory(
     typer.echo(f"Found {len(files)} files matching {pattern} in {directory}")
     csv_fname = create_csv_fname(csv_save_dir)
     with typer.progressbar(length=len(files)) as progress:
-        all_preds = []
         for i, batch in enumerate(itertoolz.partition_all(bs, files)):
             batch_predictions = onnxinference.predict_batch(batch, bs)
-            all_preds.append(list(batch_predictions.batch_labels))
             if i == 0:
                 create_csv_header(batch_predictions, csv_fname)
             write_batch_preds_to_csv(batch_predictions, csv_fname)
@@ -168,7 +166,6 @@ def predict_directory(
     ]
     columns = Columns(tables)
     print(columns)
-    # print_table(list(itertoolz.concat(all_preds)))
 
 
 def labels_from_csv(fname: Path) -> List[List[str]]:

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Iterable
 from typing import Iterator
 from typing import List
+from typing import Tuple
 from typing import Union
 
 import numpy as np
@@ -48,6 +49,14 @@ class ImagePredictionItem:
             self.path: Path = self.path.absolute()
         except AttributeError:
             pass
+
+
+@dataclass
+class MultiLabelImagePredictionItem:
+    """Multiple predictions for a single image"""
+
+    path: Path
+    predictions: List[Tuple[str, float]]
 
 
 @dataclass

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -94,6 +94,15 @@ def predict_image(
     pass  # pragma: no cover
 
 
+def check_files(files: List, pattern: str, directory: Path) -> None:
+    """Checks for files"""
+    if not files:
+        typer.echo(
+            f"Didn't find any files maching {pattern} in {directory}, please check the inputs to flyswot"
+        )
+        raise typer.Exit(code=1)
+
+
 @app.command(name="directory")
 def predict_directory(
     directory: Path = typer.Argument(

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -35,7 +35,7 @@ class ImagePredictionItem:
     Attributes:
         path: The Path to the image
         predicted_label: The predicted label i.e. the argmax value for the prediction tensor
-        condidence: The confidence for `predicted_label` i.e. the max value for prediction tensor
+        confidence: The confidence for `predicted_label` i.e. the max value for prediction tensor
     """
 
     path: Path

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -309,18 +309,20 @@ class InferenceSession(ABC):
     """Abstract class for inference sessions"""
 
     @abstractmethod
-    def __init__(self, model: Path, vocab: List):
+    def __init__(self, model: Path, vocab: List):  # pragma: no cover
         """Inference Sessions should init from a model file and vocab"""
         self.model = model
         self.vocab = vocab
 
     @abstractmethod
-    def predict_image(self, image: Path):
+    def predict_image(self, image: Path):  # pragma: no cover
         """Predict a single image"""
         pass
 
     @abstractmethod
-    def predict_batch(self, model: Path, batch: Iterable[Path], bs: int):
+    def predict_batch(
+        self, model: Path, batch: Iterable[Path], bs: int
+    ):  # pragma: no cover
         """Predict a batch"""
         pass
 
@@ -357,7 +359,7 @@ def softmax(x):
 #         return PredictionBatch(prediction_items)
 
 
-class OnnxInferenceSession(InferenceSession):
+class OnnxInferenceSession(InferenceSession):  # pragma: no cover
     """onnx inference session"""
 
     def __init__(self, model: Path, vocab: Path):
@@ -425,7 +427,7 @@ class OnnxInferenceSession(InferenceSession):
     ) -> Union[PredictionBatch, MultiPredictionBatch]:
         """predicts a batch of images"""
         prediction_items = [self.predict_image(file) for file in batch]
-        if len(self.vocab) < 1:
+        if len(self.vocab) < 2:
             return PredictionBatch(prediction_items)
         else:
             return MultiPredictionBatch(prediction_items)

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -161,22 +161,13 @@ def predict_directory(
     typer.echo(f"CSV report stored in {csv_fname}")
     delta = timedelta(seconds=time.perf_counter() - start_time)
     typer.echo(f"Time taken to run:  {str(delta)}")
-    if len(onnxinference.vocab) > 1:
-        labels_to_print = labels_from_csv(csv_fname)
-        tables = [
-            print_table(labels, f"Prediction summary {i+1}", print=False)
-            for i, labels in enumerate(labels_to_print)
-        ]
-        columns = Columns(tables)
-        print(columns)
-    else:
-        labels_to_print = labels_from_csv(csv_fname)
-        tables = [
-            print_table(labels, f"Prediction summary {i+1}", print=False)
-            for i, labels in enumerate(labels_to_print)
-        ]
-        columns = Columns(tables)
-        print(columns)
+    labels_to_print = labels_from_csv(csv_fname)
+    tables = [
+        print_table(labels, f"Prediction summary {i+1}", print=False)
+        for i, labels in enumerate(labels_to_print)
+    ]
+    columns = Columns(tables)
+    print(columns)
     # print_table(list(itertoolz.concat(all_preds)))
 
 

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -159,6 +159,11 @@ def predict_directory(
     typer.echo(f"CSV report stored in {csv_fname}")
     delta = timedelta(seconds=time.perf_counter() - start_time)
     typer.echo(f"Time taken to run:  {str(delta)}")
+    print_inference_summary(csv_fname)
+
+
+def print_inference_summary(csv_fname):
+    """print_inference_summary from `fname`"""
     labels_to_print = labels_from_csv(csv_fname)
     tables = [
         print_table(labels, f"Prediction summary {i+1}", print=False)

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -130,6 +130,7 @@ def predict_directory(
     ),
     # check_latest: bool = typer.Option(True, help="Use latest available model"),
     model_name: str = typer.Option("latest", help="Which model to use"),
+    model_path: str = None,
 ):
     """Predicts against all images stored under DIRECTORY which match PATTERN in the filename.
 
@@ -141,8 +142,10 @@ def predict_directory(
     model_dir = models.ensure_model_dir()
     if model_name == "latest":
         model_parts = models.ensure_model(model_dir, check_latest=True)
-    if model_name != "latest":
+    if model_name != "latest" and not model_path:
         model_parts = models._get_model_parts(Path(model_dir / Path(model_name)))
+    if model_name != "latest" and model_path:
+        model_parts = models._get_model_parts(Path(model_path) / Path(model_name))
     onnxinference = OnnxInferenceSession(model_parts.model, model_parts.vocab)
     files = list(core.get_image_files_from_pattern(directory, pattern, image_format))
     check_files(files, pattern, directory)

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -371,7 +371,6 @@ class OnnxInferenceSession(InferenceSession):  # pragma: no cover
 
         self.vocab = models.load_vocab(vocab)
         self.vocab_mappings = [dict(enumerate(v)) for v in self.vocab]
-        self.mode = "multi" if len(self.vocab) > 1 else "single"
 
     def predict_image(
         self, image: Path

--- a/src/flyswot/inference.py
+++ b/src/flyswot/inference.py
@@ -139,7 +139,6 @@ def predict_directory(
     """
     start_time = time.perf_counter()
     model_dir = models.ensure_model_dir()
-    # TODO add load learner function that can be passed a model name
     if model_name == "latest":
         model_parts = models.ensure_model(model_dir, check_latest=True)
     if model_name != "latest":

--- a/src/flyswot/models.py
+++ b/src/flyswot/models.py
@@ -44,9 +44,9 @@ class GitHubRelease:
 class LocalModel:
     """A local model container"""
 
-    vocab: Optional[Path]
-    modelcard: Optional[Path]
-    model: Optional[Path]
+    vocab: Path
+    modelcard: Path
+    model: Path
 
 
 def get_release_metadata(release: Dict[str, Any]) -> GitHubRelease:
@@ -169,7 +169,6 @@ def _get_latest_model(model_dir: Path) -> Optional[Path]:
 def _get_model_parts(model_dir: Path) -> LocalModel:
     """Returns model path, vocab and metadata for a model"""
     model_files = Path(model_dir / "model").iterdir()
-    vocab, modelcard, model = None, None, None
     for file in model_files:
         if fnmatch.fnmatch(file.name, "vocab.txt"):
             vocab = file
@@ -190,6 +189,11 @@ def _compare_remote_local(local_model: Path) -> bool:  # pragma: no cover
         release_metadata.updated_at.isoformat()
         > _get_model_date(local_model).isoformat()
     )
+
+
+def load_model(model_dir: Path):
+    """returns a local model"""
+    return _get_model_parts(model_dir)
 
 
 def ensure_model(

--- a/src/flyswot/models.py
+++ b/src/flyswot/models.py
@@ -260,9 +260,6 @@ def vocab(
                 console.print(Markdown("# Model Vocab"))
                 console.print(vocab)
             return vocab
-    if not model_path:
-        typer.echo(f"No models currently found in {model_path}")
-        raise typer.Exit()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/flyswot/models.py
+++ b/src/flyswot/models.py
@@ -72,7 +72,9 @@ def _url_callback(url: str) -> Union[str, None]:
         raise typer.BadParameter(f"Please check {url} is a valid url")
 
 
-def get_remote_release_json(url: str, single: bool = False) -> Dict[str, Any]:
+def get_remote_release_json(
+    url: str, single: bool = False
+) -> Dict[str, Any]:  # pragma : no cover
     """Returns all releases found at `url`"""
     with urllib.request.urlopen(url) as response:  # pragma: no cover
         try:

--- a/src/flyswot/models.py
+++ b/src/flyswot/models.py
@@ -11,16 +11,18 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import typer
 import validators  # type: ignore
 from rich.markdown import Markdown
+from toolz import itertoolz
+from toolz import recipes
 
 from flyswot.config import APP_NAME
 from flyswot.config import MODEL_REPO_URL
 from flyswot.console import console
-
 
 app = typer.Typer()
 
@@ -218,10 +220,21 @@ def ensure_model(
         raise typer.Exit()
 
 
-def load_vocab(vocab: Path) -> List[str]:
-    """loads vocab from `vocab` and returns as list"""
+def is_pipe(c: Tuple) -> bool:
+    """Checks if | in c"""
+    return "|" in c
+
+
+def load_vocab(vocab: Path) -> List[List[str]]:
+    """loads vocab from `vocab` and returns as list contaning lists of vocab"""
     with open(vocab, "r") as f:
-        return [line.strip("\n") for line in f.readlines()]
+        raw_vocab = [line.strip("\n") for line in f.readlines()]
+        return list(
+            map(
+                list,
+                (itertoolz.remove(is_pipe, (recipes.partitionby(is_pipe, raw_vocab)))),
+            )
+        )
 
 
 @app.command()

--- a/src/flyswot/models.py
+++ b/src/flyswot/models.py
@@ -191,7 +191,7 @@ def _compare_remote_local(local_model: Path) -> bool:  # pragma: no cover
     )
 
 
-def load_model(model_dir: Path):
+def load_model(model_dir: Path):  # pragma: no cover
     """returns a local model"""
     return _get_model_parts(model_dir)
 

--- a/tests/test_files/mult/20210629/model/2021-06-29-model.onnx
+++ b/tests/test_files/mult/20210629/model/2021-06-29-model.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84c8fde3fd9175e99a3580997129b342a808a67b415eea6106d93a14aa59c081
+size 108756013

--- a/tests/test_files/mult/20210629/model/modelcard.md
+++ b/tests/test_files/mult/20210629/model/modelcard.md
@@ -1,0 +1,19 @@
+# flyswot
+
+## Model description
+
+In progress model for detecting 'fake' flysheets
+
+## Intended uses & limitations
+
+Not currently intended for public consumption...
+
+#### Limitations and bias
+
+Not currently intended for public consumption...
+
+## Training data
+
+TODO
+
+## Eval results

--- a/tests/test_files/mult/20210629/model/vocab.txt
+++ b/tests/test_files/mult/20210629/model/vocab.txt
@@ -1,0 +1,18 @@
+flysheet
+other
+|
+Back flysheet
+Back folder
+Box
+Carrying case or wrapper
+Control shot
+Front flysheet
+Front folder
+Material wrapper
+Original bindings
+Other papers letters cards
+Pages
+Scroll images
+Second foliation sequence
+cover
+edge

--- a/tests/test_files/test_vocab.txt
+++ b/tests/test_files/test_vocab.txt
@@ -1,0 +1,18 @@
+flysheet
+other
+|
+Back flysheet
+Back folder
+Box
+Carrying case or wrapper
+Control shot
+Front flysheet
+Front folder
+Material wrapper
+Original bindings
+Other papers letters cards
+Pages
+Scroll images
+Second foliation sequence
+cover
+edge

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -153,6 +153,31 @@ def test_csv_header():
         inference.create_csv_header("string", Path("."))
 
 
+def test_csv_header_multi(tmp_path):
+    predicton = inference.MultiLabelImagePredictionItem(Path("."), [("label", 0.8)])
+    batch = inference.MultiPredictionBatch([predicton, predicton])
+    csv_fname = tmp_path / "test.csv"
+    inference.create_csv_header(batch, csv_fname)
+    with open(csv_fname, "r") as f:
+        reader = csv.DictReader(f)
+        list_of_column_names = [header for header in reader.fieldnames]
+    assert "path" in list_of_column_names
+    assert "directory" in list_of_column_names
+
+
+def test_csv_header_single(tmp_path):
+    predicton = inference.ImagePredictionItem(Path("."), "label", 0.6)
+    batch = inference.PredictionBatch([predicton])
+    csv_fname = tmp_path / "test.csv"
+    inference.create_csv_header(batch, csv_fname)
+    with open(csv_fname, "r") as f:
+        reader = csv.DictReader(f)
+        list_of_column_names = [header for header in reader.fieldnames]
+    assert "path" in list_of_column_names
+    assert "directory" in list_of_column_names
+    assert "confidence" in list_of_column_names
+
+
 @given(strategies.lists(st.text(min_size=2), min_size=2), st.text())
 def test_print_table(labels, title):
     table = inference.print_table(labels, title, print=False)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -156,7 +156,7 @@ def test_print_table(labels, title):
     unique = itertoolz.count(itertoolz.unique(labels))
     assert table.row_count == unique + 1
     assert all(
-        [label in getattr(itertoolz.first(table.columns), "_cells") for label in labels]
+        label in getattr(itertoolz.first(table.columns), "_cells") for label in labels
     )
 
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -134,9 +134,9 @@ def test_predict_directory(datafiles, tmp_path) -> None:
         for row in reader:
             for (k, v) in row.items():
                 columns[k].append(v)
-        assert any(["prediction" in k for k in columns])
-        labels = [columns[k] for k in columns.keys() if "prediction" in k]
-        confidences = [columns[k] for k in columns.keys() if "confidence" in k]
+        assert any("prediction" in k for k in columns)
+        labels = [columns[k] for k in columns if "prediction" in k]
+        confidences = [columns[k] for k in columns if "confidence" in k]
         # check all labels are strings
         assert all(map(lambda x: isinstance(x, str), (itertoolz.concat(labels))))
         # check all confidences can be cast to float

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -73,6 +73,26 @@ def test_prediction_batch(confidence: float, label: str, imfile: Any):
     assert hasattr(batch.batch_labels, "__next__")
 
 
+@given(confidence=st.floats(min_value=0.0, max_value=100.0), label=st.text(min_size=1))
+def test_multi_prediction_batch(confidence: float, label: str, imfile: Any):
+    item = inference.MultiLabelImagePredictionItem(
+        imfile, [(label, confidence), (label, confidence)]
+    )
+    item2 = inference.MultiLabelImagePredictionItem(
+        imfile, [(label, confidence), (label, confidence)]
+    )
+    batch = inference.MultiPredictionBatch([item, item2])
+    assert batch.batch
+    assert type(batch.batch) == list
+    assert type(batch.batch[0]) == inference.MultiLabelImagePredictionItem
+    assert batch.batch_labels
+    assert len(list(batch.batch_labels)) == 2
+    assert hasattr(batch.batch_labels, "__next__")
+    for labels in batch.batch_labels:
+        for label in labels:
+            assert label == label
+
+
 FIXTURE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     "test_files",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -204,6 +204,7 @@ def test_print_table(labels, title):
     assert all(
         label in getattr(itertoolz.first(table.columns), "_cells") for label in labels
     )
+    table = inference.print_table(labels, title, print=True)
 
 
 @given(strategies.lists(st.text(), min_size=1))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -178,6 +178,22 @@ def test_csv_header_single(tmp_path):
     assert "confidence" in list_of_column_names
 
 
+def test_csv_batch():
+    with pytest.raises(NotImplementedError):
+        inference.write_batch_preds_to_csv("string", Path("."))
+
+
+def test_csv_batch_single(tmp_path):
+    predicton = inference.ImagePredictionItem(Path("."), "label", 0.6)
+    batch = inference.PredictionBatch([predicton])
+    csv_fname = tmp_path / "test.csv"
+    inference.write_batch_preds_to_csv(batch, csv_fname)
+    with open(csv_fname, "r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            assert "label" in row
+
+
 @given(strategies.lists(st.text(min_size=2), min_size=2), st.text())
 def test_print_table(labels, title):
     table = inference.print_table(labels, title, print=False)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -50,6 +50,20 @@ def test_image_prediction_item(confidence, label, imfile: Any):
 
 
 @given(confidence=st.floats(max_value=100.0), label=st.text(min_size=1))
+def test_multi_image_prediction_item(confidence, label, imfile: Any):
+    item = inference.MultiLabelImagePredictionItem(
+        imfile, [(label, confidence), (label, confidence)]
+    )
+    assert item.path == imfile
+    assert type(item.predictions) == list
+    assert type(item.predictions[0]) == tuple
+    assert item.predictions[0][0] == label
+    assert item.predictions[1][0] == label
+    assert item.predictions[0][1] == confidence
+    assert item.predictions[1][1] == confidence
+
+
+@given(confidence=st.floats(max_value=100.0), label=st.text(min_size=1))
 def test_prediction_batch(confidence: float, label: str, imfile: Any):
     item = inference.ImagePredictionItem(imfile, label, confidence)
     item2 = inference.ImagePredictionItem(imfile, label, confidence)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -148,6 +148,18 @@ def test_predict_directory(datafiles, tmp_path) -> None:
         )
 
 
+@given(strategies.lists(st.text(min_size=2), min_size=2), st.text())
+def test_print_table(labels, title):
+    table = inference.print_table(labels, title, print=False)
+    assert isinstance(table, rich.table.Table)
+    assert table.title == title
+    unique = itertoolz.count(itertoolz.unique(labels))
+    assert table.row_count == unique + 1
+    assert all(
+        [label in getattr(itertoolz.first(table.columns), "_cells") for label in labels]
+    )
+
+
 @given(strategies.lists(st.text(), min_size=1))
 def test_check_files(l):
     inference.check_files(l, "fse", Path("."))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -14,7 +14,7 @@ from flyswot import inference
 # flake8: noqa
 
 
-def test__image_predicton_item_raises_error_when_too_few_params():
+def test__image_prediction_item_raises_error_when_too_few_params():
     """It raises Typerror when passed too few items"""
     with pytest.raises(TypeError):
         item = inference.ImagePredictionItem("A")

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -148,6 +148,11 @@ def test_predict_directory(datafiles, tmp_path) -> None:
         )
 
 
+def test_csv_header():
+    with pytest.raises(NotImplementedError):
+        inference.create_csv_header("string", Path("."))
+
+
 @given(strategies.lists(st.text(min_size=2), min_size=2), st.text())
 def test_print_table(labels, title):
     table = inference.print_table(labels, title, print=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ from flyswot import models
 from flyswot.models import app
 from flyswot.models import ensure_model_dir
 from flyswot.models import load_vocab
+from flyswot.models import vocab
 
 runner = CliRunner()
 
@@ -204,6 +205,17 @@ def test_load_vocab() -> None:
     assert vocab
     assert type(vocab) == list
     assert type(vocab[0]) == list
+
+
+def test_vocab_raises() -> None:
+    with pytest.raises(NotImplementedError):
+        models.vocab(model="not_latest")
+
+
+def test_vocab() -> None:
+    vocab = models.vocab(model="latest", show=False)
+    assert vocab
+    assert isinstance(vocab, list)
 
 
 def test_app(tmp_path: Any) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ from typing_extensions import runtime
 from flyswot import models
 from flyswot.models import app
 from flyswot.models import ensure_model_dir
+from flyswot.models import load_vocab
 
 runner = CliRunner()
 
@@ -196,6 +197,13 @@ def test_ensure_model() -> None:
     model_dir = ensure_model_dir()
     model_parts = models.ensure_model(model_dir)
     assert model_parts
+
+
+def test_load_vocab() -> None:
+    vocab = models.load_vocab(Path("tests/test_files/test_vocab.txt"))
+    assert vocab
+    assert type(vocab) == list
+    assert type(vocab[0]) == list
 
 
 def test_app(tmp_path: Any) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -218,5 +218,12 @@ def test_vocab() -> None:
     assert isinstance(vocab, list)
 
 
+def test_vocab_print(capsys) -> None:
+    models.vocab(model="latest", show=True)
+    captured = capsys.readouterr()
+    assert len(captured.out) > 2
+    assert "Model Vocab" in captured.out
+
+
 def test_app(tmp_path: Any) -> None:
     pass


### PR DESCRIPTION
closes #154 
- adds support for multi-task/head models
	- adds support for printing reports containing multiple label groups
	- adds support for writing multiple labels groups to csv
- improved test coverage for inference methods