### PR TITLE
add python 3.7 and 3.8 windows to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ jobs:
           - { python-version: 3.9, os: ubuntu-latest, session: "pre-commit" }
           - { python-version: 3.9, os: ubuntu-latest, session: "safety" }
           - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
+          - { python-version: 3.7, os: windows-latest, session: "tests" }
           - { python-version: 3.8, os: windows-latest, session: "tests" }
+          - { python-version: 3.9, os: windows-latest, session: "tests" }
           - { python-version: 3.9, os: ubuntu-latest, session: "xdoctest" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs-build" }
 


### PR DESCRIPTION
test across all supported Python versions on windows